### PR TITLE
pid file names are not unique if two steps have identical script content

### DIFF
--- a/src/main/java/com/bioraft/rundeck/rancher/RancherNodeExecutorPlugin.java
+++ b/src/main/java/com/bioraft/rundeck/rancher/RancherNodeExecutorPlugin.java
@@ -18,11 +18,7 @@ package com.bioraft.rundeck.rancher;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-
-import javax.xml.bind.DatatypeConverter;
 
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
@@ -124,17 +120,9 @@ public class RancherNodeExecutorPlugin implements NodeExecutor, Describable {
 	 * @return
 	 */
 	private String baseName(String[] command, Map<String, String> jobContext) {
-		MessageDigest md;
-		try {
-			md = MessageDigest.getInstance("MD5");
-			md.update(String.join(" ", command).getBytes());
-			byte[] digest = md.digest();
-			String md5 = DatatypeConverter.printHexBinary(digest);
-			return "/tmp/" + jobContext.get("project") + "_" + jobContext.get("execid") + "_" + md5;
-		} catch (NoSuchAlgorithmException e) {
-			e.printStackTrace();
-			return "/tmp/rundeck_job";
-		}
+		long time = System.currentTimeMillis();
+		int hash = command.hashCode();
+		return "/tmp/" + jobContext.get("project") + "_" + jobContext.get("execid") + time + "_" + hash;
 	}
 
 	/**


### PR DESCRIPTION
If names collide, exit status cannot be reliably reported.

Patch replaces md5 hash with system time in milliseconds plus java String.hashCode()