### PR TITLE
When copying file, movement of temp file should be debug-only message resolves #26

### DIFF
--- a/src/main/java/com/bioraft/rundeck/rancher/RancherFileCopier.java
+++ b/src/main/java/com/bioraft/rundeck/rancher/RancherFileCopier.java
@@ -38,6 +38,7 @@ import com.dtolabs.rundeck.core.Constants;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
+import com.dtolabs.rundeck.core.execution.ExecutionLogger;
 import com.dtolabs.rundeck.core.execution.impl.common.BaseFileCopier;
 import com.dtolabs.rundeck.core.execution.script.ScriptfileUtils;
 import com.dtolabs.rundeck.core.execution.service.FileCopier;
@@ -135,8 +136,10 @@ public class RancherFileCopier implements FileCopier, Describable {
                 : BaseFileCopier.writeTempFile(context, scriptfile, input, script);
 
         // Copy the file over
-        System.out.println("copying file: '" + localTempfile.getAbsolutePath() + "' to: '" + node.getNodename() + ":"
-                + remotefile + "'");
+        ExecutionLogger logger = context.getExecutionLogger();
+        String absPath = localTempfile.getAbsolutePath();
+        String message = "copying file: '" + absPath + "' to: '" + node.getNodename() + ":" + remotefile + "'";
+        logger.log(DEBUG_LEVEL, message);
 
         Framework framework = context.getFramework();
         String project = context.getFrameworkProject();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Issue #26 

* **What is the new behavior (if this is a feature change)?**

Normal operation does not show debug message

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. Only workflows that tried to capture the file name as a variable would be changed, but file copy provides that information as a variable anyway.